### PR TITLE
Mirror the order of the gpio_decoder indices

### DIFF
--- a/drivers/platform/x86/zii-rap.c
+++ b/drivers/platform/x86/zii-rap.c
@@ -167,10 +167,10 @@ static void zii_rap_keys(struct device *dev)
 static struct gpiod_lookup_table zii_rap_decoder_gpiod_table = {
 	.dev_id = "Pinstrap input from J3.1",
 	.table = {
-		GPIO_LOOKUP_IDX("sx1502q", 0, NULL, 0, GPIO_ACTIVE_LOW),
-		GPIO_LOOKUP_IDX("sx1502q", 1, NULL, 1, GPIO_ACTIVE_LOW),
-		GPIO_LOOKUP_IDX("sx1502q", 2, NULL, 2, GPIO_ACTIVE_LOW),
-		GPIO_LOOKUP_IDX("sx1502q", 3, NULL, 3, GPIO_ACTIVE_LOW),
+		GPIO_LOOKUP_IDX("sx1502q", 0, NULL, 3, GPIO_ACTIVE_LOW),
+		GPIO_LOOKUP_IDX("sx1502q", 1, NULL, 2, GPIO_ACTIVE_LOW),
+		GPIO_LOOKUP_IDX("sx1502q", 2, NULL, 1, GPIO_ACTIVE_LOW),
+		GPIO_LOOKUP_IDX("sx1502q", 3, NULL, 0, GPIO_ACTIVE_LOW),
 		{ },
 	}
 };


### PR DESCRIPTION
When testing on a RaveAP and sequencing the pinstrapping pins value from 0 to 15, I read back the following sequence from the input driver:
```
0
8
4
12
2
10
6
14
1
9
5
13
3
11
7
15
0
```

With the suggested change, I get the correct 0-15 sequence instead.